### PR TITLE
feat: add GitHub Actions workflow for auto-assigning PR assignees

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,20 @@
+name: Auto Assign PR Assignees
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-assignees:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      repository-projects: read
+    timeout-minutes: 5
+    if: github.event.pull_request.assignee == null
+    steps:
+      - name: Auto Assign PR Assignees
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: gh pr edit ${{ github.event.number }} --add-assignee ${{ github.actor }}
+

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 5
     if: github.event.pull_request.assignee == null
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Auto Assign PR Assignees
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically assign pull request assignees when a pull request is opened or marked as ready for review.

Workflow automation:

* [`.github/workflows/auto-assign.yml`](diffhunk://#diff-3df58dd42b351a284a19d2c3d3fe8c50db1cc811bb690ebbf402d1282bce9757R1-R20): Added a new workflow named "Auto Assign PR Assignees" which triggers on pull request events and assigns the pull request to the creator if no assignee is set.